### PR TITLE
Arreglando errores de analizador lexico

### DIFF
--- a/lexicalAnalizer.l
+++ b/lexicalAnalizer.l
@@ -98,11 +98,11 @@ FLOAT           {DIGITO}+"."{DIGITO}+(e[+-]?{DIGITO}+)?
 
 %%
 
-{ENTERO}         { fprintf(archivoSalida, "Token: Clase 0, Valor: %d\n", tabla_literales_enteros.cantidad);
+{ENTERO}         { fprintf(archivoSalida, "Token: Clase 0, Valor: %s\n", yytext);
                     insertar_literal_entero(&tabla_literales_enteros, yytext);
                   }
 
-\s*([0-9]+)(u|l|ul|U|L|UL) { fprintf(archivoSalida, "Token: Clase 0, Valor: %d\n", tabla_literales_enteros.cantidad);
+\s*([0-9]+)(u|l|ul|U|L|UL) { fprintf(archivoSalida, "Token: Clase 0, Valor: %s\n", yytext);
                              insertar_literal_entero(&tabla_literales_enteros, yytext);
                             }
 

--- a/lexicalAnalizer.l
+++ b/lexicalAnalizer.l
@@ -90,6 +90,10 @@ FLOAT           {DIGITO}+"."{DIGITO}+(e[+-]?{DIGITO}+)?
                     insertar_literal_entero(&tabla_literales_enteros, yytext);
                   }
 
+\s*([0-9]+)(u|l|ul|U|L|UL) { fprintf(archivoSalida, "Token: Clase 0, Valor: %d\n", tabla_literales_enteros.cantidad);
+                             insertar_literal_entero(&tabla_literales_enteros, yytext);
+                            }
+
 {FLOAT}          { fprintf(archivoSalida, "Token: Clase 1, Valor: %d\n", tabla_literales_flotantes.cantidad);
                     insertar_literal_flotante(&tabla_literales_flotantes, yytext);
                   }

--- a/lexicalAnalizer.l
+++ b/lexicalAnalizer.l
@@ -19,7 +19,7 @@
 // estructura para guardar los simbolos
 typedef struct {
     int posicion;
-    char nombre[16];
+    char nombre[14];
     int tipo;
 } Simbolo;
 
@@ -162,9 +162,14 @@ FLOAT           {DIGITO}+"."{DIGITO}+(e[+-]?{DIGITO}+)?
 "&&"             { fprintf(archivoSalida, "Token: Clase 7, Valor: 1\n"); }
 "!"              { fprintf(archivoSalida, "Token: Clase 7, Valor: 2\n"); }
 
-{IDENT}          { fprintf(archivoSalida, "Token: Clase 8, Valor: %d\n", tabla_simbolos.cantidad);
-                    insertar_simbolo(&tabla_simbolos, yytext);
-                  }
+{IDENT}          {
+                    if (strlen(yytext) > 15) {
+                        fprintf(archivoSalida, "Error léxico: Identificador excede los 15 caracteres: %s\n", yytext);
+                    } else {
+                        fprintf(archivoSalida, "Token: Clase 8, Valor: %d\n", tabla_simbolos.cantidad);
+                        insertar_simbolo(&tabla_simbolos, yytext);
+                    }
+                 }
 
 {COMMENT_LINE}   { }
 {COMMENT_BLOCK}  { }

--- a/lexicalAnalizer.l
+++ b/lexicalAnalizer.l
@@ -1,4 +1,16 @@
 %{
+/*
+    Compiladores -------------------
+
+    Autores:
+        - Montiel Aviles Axel Fernando
+        - Guadarrama Herrera Ken Bryan
+    
+    Objetivo: Construir, en un mismo programa, los analizadores Lexico y Sintactico Descendente
+        Recursivo que revisen programas escritos en el lenguaje definido por la gramatica del
+        Anexo A de este documento.
+*/
+
 // bibliotecas estandar
 #include <stdio.h>
 #include <stdlib.h>
@@ -163,9 +175,20 @@ FLOAT           {DIGITO}+"."{DIGITO}+(e[+-]?{DIGITO}+)?
 
 %%
 
+/**
+ * Funcion principal para correr el programa
+ * @param argc numero de argumentos
+ * @param argv apuntadores de argumentos
+ * @return retorna entero
+ */
 int main(int argc, char **argv) {
+
+    // si se corre el programa usando argumentos
     if (argc > 1) {
+        // abrir el archivo de codigo fuente
         archivoEntrada = fopen(argv[1], "r");
+
+        // si el archivo no existe o no se encuentra
         if (!archivoEntrada) {
             perror("Error al abrir el archivo");
             return 1;
@@ -176,18 +199,25 @@ int main(int argc, char **argv) {
 
         // si se elige un archivo de salida, escribimos en este
         if(argc > 2) {
+            // creamos un archivo leyendo el argumento 2
             archivoSalida = fopen(argv[2], "w");
+
+            // si ocurre un error al momento de crear el archivo
             if (!archivoSalida) {
                 perror("Error al abrir el archivo de salida");
                 return 1;
             }
-        } // si no se proporciona el archivo de salida, usamos la consola
+        }
+        // si no se proporciona el archivo de salida, usamos la consola
         else {  
-            archivoSalida = stdout;  // Si no se proporciona archivo de salida, usar la consola
+            archivoSalida = stdout;
         }
     }
 
+    // llamada el comando de lex para la creacion de una maquina de estados finitos
     yylex();
+
+    // impresion de cada una de las tablas generadas
 
     fprintf(archivoSalida, "Tabla de símbolos:\n");
     for (int i = 0; i < tabla_simbolos.cantidad; i++) {
@@ -212,33 +242,79 @@ int main(int argc, char **argv) {
     return 0;
 }
 
+
+/**
+ * Funcion para insertar simbolo/identificadores
+ * @param TablaSimbolos instancia de la tabla de simbolos
+ * @param nombre nombre de identificador
+ * @return void
+ */
 void insertar_simbolo(TablaSimbolos *tabla, const char *nombre) {
-    for (int i = 0; i < tabla->cantidad; i++) {
+
+    // buscamos si es que ya existe ese identificador en la tabla de simbolos
+    for (int i = 0; i < tabla->cantidad; i++) { // O(n)
         if (strcmp(tabla->simbolos[i].nombre, nombre) == 0) {
+            // si se encontro el mismo identificador, matamos la funcion
             return;
         }
     }
+
+    //si es un nuevo simbolo ...
+
+    // copiamos el simbolo a la tabla
     strcpy(tabla->simbolos[tabla->cantidad].nombre, nombre);
+
     tabla->simbolos[tabla->cantidad].tipo = -1;
-    tabla->cantidad++;
+    tabla->cantidad++; // aumentamos la longitud de la tabla
 }
 
+
+/**
+ * Funcion para insertar literales cadena
+ * @param TablaLiteralesCadenas instancia de la tabla de literales de cadena
+ * @param dato literal cadena
+ * @return void
+ */
 void insertar_literal_cadena(TablaLiteralesCadenas *tabla, const char *dato) {
+    // copiamos la cadena a la tabla
     strcpy(tabla->cadenas[tabla->cantidad].dato, dato);
-    tabla->cantidad++;
+    tabla->cantidad++; // aumentamos la longitud de la tabla
 }
 
+
+/**
+ * Funcion para insertar literales flotantes
+ * @param TablaLiteralesFlotantes instancia de la tabla de literales flotantes
+ * @param dato literal flotante
+ * @return void
+ */
 void insertar_literal_flotante(TablaLiteralesFlotantes *tabla, const char *dato) {
+    // copiamos el flotante a la tabla
     strcpy(tabla->flotantes[tabla->cantidad].dato, dato);
-    tabla->cantidad++;
+    tabla->cantidad++; // aumentamos la longitud de la tabla
 }
 
+
+/**
+ * Funcion para insertar literales enteras
+ * @param TablaLiteralesEnteros instancia de la tabla de literales enteras
+ * @param dato literal entera
+ * @return void
+ */
 void insertar_literal_entero(TablaLiteralesEnteros *tabla, const char *dato) {
-    for (int i = 0; i < tabla->cantidad; i++) {
+
+    // buscamos si es que ya existe ese entero en la tabla de enteros
+    for (int i = 0; i < tabla->cantidad; i++) { // O(n)
         if (strcmp(tabla->enteros[i].dato, dato) == 0) {
+            // si se encontro el mismo identificador, matamos la funcion
             return;
         }
     }
+
+    //si es un nuevo entero ...
+
+    // copiamos el entero a la tabla
     strcpy(tabla->enteros[tabla->cantidad].dato, dato);
-    tabla->cantidad++;
+
+    tabla->cantidad++; // aumentamos la longitud de la tabla
 }

--- a/lexicalAnalizer.l
+++ b/lexicalAnalizer.l
@@ -132,6 +132,15 @@ FLOAT           {DIGITO}+"."{DIGITO}+(e[+-]?{DIGITO}+)?
 
 "="              { fprintf(archivoSalida, "Token: Clase 6, Valor: 0\n"); }
 "\+="            { fprintf(archivoSalida, "Token: Clase 6, Valor: 1\n"); }
+"\-="            { fprintf(archivoSalida, "Token: Clase 6, Valor: 2\n"); }
+"\*="            { fprintf(archivoSalida, "Token: Clase 6, Valor: 3\n"); }
+"\/="            { fprintf(archivoSalida, "Token: Clase 6, Valor: 4\n"); }
+"\%="            { fprintf(archivoSalida, "Token: Clase 6, Valor: 5\n"); }
+"\&="            { fprintf(archivoSalida, "Token: Clase 6, Valor: 6\n"); }
+"\^="            { fprintf(archivoSalida, "Token: Clase 6, Valor: 7\n"); }
+"\|="            { fprintf(archivoSalida, "Token: Clase 6, Valor: 8\n"); }
+"<<="            { fprintf(archivoSalida, "Token: Clase 6, Valor: 9\n"); }
+">>="            { fprintf(archivoSalida, "Token: Clase 6, Valor: 10\n"); }
 
 "\|\|"           { fprintf(archivoSalida, "Token: Clase 7, Valor: 0\n"); }
 "&&"             { fprintf(archivoSalida, "Token: Clase 7, Valor: 1\n"); }

--- a/source.txt
+++ b/source.txt
@@ -22,6 +22,9 @@ INT SUM(INT a) {
     RETURN a+12.
 }
 
+~~ constante entera
+INT enteraUnsigned = 25ul.
+
 ~~ operadores de asignacion
 INT y = 10.
 

--- a/source.txt
+++ b/source.txt
@@ -4,6 +4,9 @@ STRING name2 = #KENCHO#.
 
 STRING copia_Axel = #AXEL BLA#.
 
+INT x12345678901234567123131 = 12.
+STRING name123456789012 = #MARGARET#.
+
 ~/
 Ciclo while para sumar hasta que
 x sea 15

--- a/source.txt
+++ b/source.txt
@@ -23,7 +23,9 @@ INT SUM(INT a) {
 }
 
 ~~ constante entera
-INT enteraUnsigned = 25ul.
+INT enteraUnsignedL = 25ul.
+INT enteraUnsigned = 65u.
+INT enteraLong = 32l.
 
 ~~ operadores de asignacion
 INT y = 10.


### PR DESCRIPTION
Se solucionaron los siguientes errores:

No reconoce varios operadores de asignación como <<=, >>=, &=, etc.
No reconoce constantes enteras como 25ul.
No acotan el tamaño de los identificadores.
En el token de las constantes enteras, el valor debe ser su valor entero.